### PR TITLE
Fix npm installation issues

### DIFF
--- a/packages/plugin-knex-database/src/index.ts
+++ b/packages/plugin-knex-database/src/index.ts
@@ -264,7 +264,8 @@ function createPlugin(db: Knex) {
                 description: version.description,
                 readme: version.readme,
                 readme_type: version.readmeType,
-                asset_hash: version.assetHash
+                asset_hash: version.assetHash,
+                metafile: version.metafile
             });
 
             for (const tag of version.tags) {

--- a/packages/plugin-npm/src/index.ts
+++ b/packages/plugin-npm/src/index.ts
@@ -214,6 +214,8 @@ const pluginExport: PluginExport<never, false> = {
                         );
                     }
 
+                    const feed = await dbPlugin.getFeedFromId(feedId);
+
                     const canViewPackage = await authPlugin.check(accessToken, {
                         kind: "package.view",
                         feedSlug,
@@ -323,7 +325,7 @@ const pluginExport: PluginExport<never, false> = {
                     );
 
                     const baseInfo = {
-                        name: pkg.name,
+                        name: `@${feed.slug}/${pkg.slug}`,
                         description: pkg.description,
                         readme: latestVersion.readme
                     };


### PR DESCRIPTION
This PR fixes npm packages installing with the version "undefined" and also using generating an alias which breaks things.

Basically, I forgot to include `metafile` in the knex plugin, and I thought for some reason that the `name` field in the package metadata that npm gets was the display name, not the slug.